### PR TITLE
notifications working across browser 

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -33,7 +33,7 @@ class ProjectsController < ApplicationController
   private
 
   def project_params
-    @new_project = params.require(:project).permit(:name, :description, :status)
+    @new_project = params.require(:project).permit(:name, :description, :manager, :status)
   end
 
 end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -9,7 +9,6 @@ class RegistrationsController < Devise::RegistrationsController
 
   def sign_up_params
     @thisuser = params.require(:user).permit(:first_name, :last_name, :email, :password, :password_confirmation, :org_id, :status)  
-
   end
 
 
@@ -19,8 +18,13 @@ class RegistrationsController < Devise::RegistrationsController
 
 
   def after_sign_in_path_for(users)
-    org = current_user.org_id
+    
     if current_user.own?
+      org = Org.where(:id => current_user.org_id).first
+      if org.owner == nil
+        org.owner = current_user.id
+        org.save
+      end
       org_path(org)
     elsif current_user.mng?
       org_path(org)

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -14,7 +14,15 @@ class TasksController < ApplicationController
     @project = Project.find(params[:project_id])
     @task = @project.tasks.create(task_params)
     # redirect_to org_project_path(current_user.org_id,@project)
-    redirect_to org_path(current_user.org_id)
+
+    if @task.save 
+      recipient = User.where(:id => @task.user_id).first
+      message = "#{current_user.first_name} has assigned a new task to you"
+      notification = Notification.create(:recipient => recipient, :actor => current_user, :action => message, :notifiable => @task)
+      notification.save
+      redirect_to org_path(current_user.org_id)
+    end
+    
   end
 
   def show
@@ -26,11 +34,11 @@ class TasksController < ApplicationController
   def update
     @project = Project.find(params[:project_id])
     @task = Task.find(params[:id]) 
+    previous_due_date = @task.due_date
     @task.update_attributes(task_params)
 
     if @task.valid?
-      previous_due_date = @task.due_date
-      change_to(previous_due_date)
+      change_to(previous_due_date,@task)
       redirect_to org_project_path(current_user.org_id,@project.id)
     else
       return render :edit, status: :unprocessable_entity
@@ -38,12 +46,17 @@ class TasksController < ApplicationController
   end
 
 
-  def change_to(previous_due_date)
-    if @task.due_date == previous_due_date
-      # duration changed, change all dependencies
+  def change_to(previous_due_date,end_task)
+    if @task.due_date != previous_due_date
+
+      # manager changed project end date - ergo due date has changed for @task, notify TP of @task...
+      helpers.notify_task_performer_manager_changed_project_end_date(end_task,true)
+      
+      # ... and notify all TPs for all dependencies of @task (i.e the last task)
       new_start_date = helpers.calculate_task_start_date(@task.due_date,@task.duration,false)
       stack = []
-      helpers.update_dependency_enddate_for(@task.id,new_start_date,stack)
+      dependency_tasks = []
+      helpers.update_dependency_enddate_for(@task.id,new_start_date,stack,dependency_tasks,true)
 
     end
   end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -85,76 +85,80 @@
 
 <script type="text/javascript">
 
-$(function() {
-
-  //generate the current date
-  var today = new Date();
-  var dd = today.getDate();
-  var mm = today.getMonth() + 1; //January is 0!
-  var yyyy = today.getFullYear();
-
-  if (dd < 10) {
-    dd = '0' + dd;
-  }
-
-  if (mm < 10) {
-    mm = '0' + mm;
-  }
-
-  today = mm + '/' + dd + '/' + yyyy;
-  
-  // get the json format notifications for current user - from view/notifications/index
-  $.get("/notifications.json").success( function( data ) {
-
-    // for each notification in data array build thge notification into html text
-    var htmlString = "";
-
-    $.each(data, function(index, notification) {
-      htmlElement = '<a class="dropdown-item" id= "' + notification.id + '" href="' + notification.url + '">' + notification.action + '</a>'
-      htmlString += htmlElement;
-    });
-
-    // get DOM reference to notifications and count flag and set their HTML/text
-    var notificationList = $('.notification-listing');
-    var notificationCount = $('.badge');
-    notificationList.html(htmlString);
-    notificationCount.text(data.length)
-
-    // get reference to each of the <a> tags which the above inserts
-    var notificationLinks = document.getElementById('notification-links');
-    var notificationLinkItems = notificationLinks.getElementsByTagName('a');
-
-    // map through and for each build on click method that passes notification id to
-    // notification post url - enables us to mark each notification clicked as read
-    $.each(notificationLinkItems, function(index, notification) {
-
-      notificationLinkItems[index].onclick = function (e) {
-        let notificationId = e.path[0].id
-        // console.log(notificationId)
-
-        $.post("/notifications/" + notificationId, {
-          _method: "PUT",
-          notification: {
-            read_at: today // NB: not used, we just use notificationID to find notification and set in notification controller update method to today's date
-          }
-        });
-      }
-
-    });
-
-    
-
-
-
-
+  $(function() {
+    generateNotificationAlerts();
   });
 
 
+  function getDateToday() {
+    //generate the current date
+    var today = new Date();
+    var dd = today.getDate();
+    var mm = today.getMonth() + 1; //January is 0!
+    var yyyy = today.getFullYear();
 
-});
+    if (dd < 10) { dd = '0' + dd; }
+    if (mm < 10) { mm = '0' + mm; }
+
+    today = mm + '/' + dd + '/' + yyyy;
+    return today
+  }
 
 
 
+  function generateNotificationAlerts() {
+
+    let today = getDateToday();
+
+    // get the json format notifications for current user - from view/notifications/index
+    $.get("/notifications.json").success( function( data ) {
+      buildNotifications(data);
+    });
+
+  }
+
+
+
+  function buildNotifications(data) {
+
+      // for each notification in data array build the notification into html text
+      var htmlString = "";
+
+      $.each(data, function(index, notification) {
+
+        htmlElement = '<a class="dropdown-item" id= "' + notification.id + '" href="' + notification.url + '">' + notification.action + '</a>'
+        htmlString += htmlElement;
+
+      });
+
+      // get DOM reference to notifications and count flag and set their HTML/text
+      var notificationList = $('.notification-listing');
+      var notificationCount = $('.badge');
+      notificationList.html(htmlString);
+      notificationCount.text(data.length)
+
+      // get reference to each of the <a> tags which the above inserts
+      var notificationLinks = document.getElementById('notification-links');
+      var notificationLinkItems = notificationLinks.getElementsByTagName('a');
+
+      // map through and for each build on click method that passes notification id to
+      // notification post url - enables us to mark each notification clicked as read
+      $.each(notificationLinkItems, function(index, notification) {
+          notification.onclick = function (e) {
+          // let notificationId = e.path[0].id
+          notificationId = notification.id;
+          // console.log(notificationId);
+
+            $.post("/notifications/" + notificationId, {
+              _method: "PUT",
+              notification: {
+                read_at: today // NB: not used, we just use notificationID to find notification and set in notification controller update method to today's date
+              }
+            });
+        }
+      });
+
+  }
 
 </script>
 

--- a/app/views/notifications/index.json.jbuilder
+++ b/app/views/notifications/index.json.jbuilder
@@ -4,11 +4,22 @@ json.array! @notifications do |notification|
   #json.template render partial: "notifications/#{notification.notifiable_type.underscore.pluralize}/#{notification.action}", locals: {notification: notification}, formats: [:html]
 
   # json.recipient notification.recipient
+
   json.id notification.id
+  json.type notification.notifiable_type
   json.actorfirstname notification.actor.first_name
   json.actorlastname notification.actor.last_name
   json.action notification.action
   json.notifiable notification.notifiable
-  json.url performer_org_project_task_path(current_user.org_id, notification.notifiable.project_id, notification.notifiable_id)
+
+  # if the notification is for TP to look at task assigned to them they need standard TP view
+  if notification.notifiable_type == "Task"
+    json.url performer_org_project_task_path(current_user.org_id, notification.notifiable.project_id, notification.notifiable_id)
+  else
+    # if the notification id for manager they should be sent to project page
+    json.url org_project_path(current_user.org_id, notification.notifiable.id)
+  end
+  # if the notification is to confirm TP accepted a task you created - view only page
+
 end
 

--- a/app/views/orgs/show.html.erb
+++ b/app/views/orgs/show.html.erb
@@ -105,7 +105,7 @@
             <!-- project description -->
             <%= f.input :description, validate: true, label: "... do you want to give it a description?", placeholder: "enter optional description", input_html: { id: "projectdesc" } %>
 
-            <!-- These fields we are misusing, since we are using AJAX to submit-->
+            <!-- status field we are misusing, since we are using AJAX to submit-->
             <!-- field_for not working in modal, hence misuse of parent fields -->
             <%= f.hidden_field :status, :id=>"user_id_field" %> 
             
@@ -367,6 +367,7 @@
       let taskName = document.getElementById('taskname').value;
       let taskDueDate = document.getElementById('date').value;
       let orgId = <%= current_user.org.id %>;
+      let projectManager = <%= current_user.id %>
 
       if ( projectName == "" || projectDescription == "") {
         alert("please give your project a name and short description to continue.");
@@ -382,6 +383,7 @@
             project: {
               name: projectName,
               description: projectDescription,
+              manager: projectManager,
               status: "PLANNING IN PROGRESS"
             }
           };

--- a/app/views/performer/tasks/show.html.erb
+++ b/app/views/performer/tasks/show.html.erb
@@ -1,4 +1,9 @@
 <% user = User.where(:id => @task.user_id).first %>
+<% user_assigned_to_this_task = false %>
+<% if user == current_user %>
+  <% user_assigned_to_this_task = true %>
+<% end %>
+
 <h1>task performers show task page</h1>
 <br /><br />
 <div class="col12 offset-1">
@@ -12,10 +17,12 @@
         due date: <%= @task.due_date %><br />
         assigned to: <%= user.email %><br /><br />
 
-        <% if @task.status == "NEW" %>
-          <%= link_to "accept task", edit_performer_org_project_task_path(current_user.org, @task.project_id, @task), class: 'btn btn-success' %>
-        <% else %>
-          <%= link_to "edit task", edit_performer_org_project_task_path(current_user.org, @task.project_id, @task), class: 'btn btn-success' %>
+        <% if user_assigned_to_this_task %>
+          <% if @task.status == "NEW" %>
+            <%= link_to "accept task", edit_performer_org_project_task_path(current_user.org, @task.project_id, @task), class: 'btn btn-success' %>
+          <% else %>
+            <%= link_to "edit task", edit_performer_org_project_task_path(current_user.org, @task.project_id, @task), class: 'btn btn-success' %>
+          <% end %>
         <% end %>
 
     </div>
@@ -28,14 +35,16 @@
       <%= link_to dependency.title, performer_org_project_task_path(current_user.org, @task.project_id, dependency.id), class: 'nav-link' %><br />
       <% end %>
       <br />
-      <% if @task.status == "NEW" %>
-        <h5>you will need to accept this task first then you can create dependency tasks </h5>
-      <% else %>
-        <%= link_to 'create a new task as dependency', new_performer_org_project_task_path(current_user.org, @task.project_id, :parent_task => @task), class: 'btn btn-success' %>
-        <br /><br />
-        <%= link_to 'select existing task as dependency', new_performer_org_project_prerequisites_path(current_user.org, @task.project_id, :parent_task => @task), class: 'btn btn-success' %>
-        <!-- Button trigger modal -->
-        <%= link_to 'select existing task as dependency2', '#', data: {toggle: 'modal', target: '#myModal'}, class: 'btn btn-success' %>
+      <% if user_assigned_to_this_task %>
+        <% if @task.status == "NEW" %>
+          <h5>you will need to accept this task first then you can create dependency tasks </h5>
+        <% else %>
+          <%= link_to 'create a new task as dependency', new_performer_org_project_task_path(current_user.org, @task.project_id, :parent_task => @task), class: 'btn btn-success' %>
+          <br /><br />
+          <%= link_to 'select existing task as dependency', new_performer_org_project_prerequisites_path(current_user.org, @task.project_id, :parent_task => @task), class: 'btn btn-success' %>
+          <!-- Button trigger modal -->
+          <%= link_to 'select existing task as dependency2', '#', data: {toggle: 'modal', target: '#myModal'}, class: 'btn btn-success' %>
+        <% end %>
       <% end %>
     </div>
 
@@ -56,7 +65,11 @@
 
 <br />
 <div class = "cnt-txt">
-  <%= link_to 'back to project page', performer_org_project_path(current_user.org, @task.project_id), class: 'btn btn-success' %>
+  <% if user_assigned_to_this_task %>
+    <%= link_to 'back to project page', performer_org_project_path(current_user.org, @task.project_id), class: 'btn btn-success' %>
+  <% else %>
+    <%= link_to 'back', :back, class: 'btn btn-success' %>
+  <% end %>
 </div>
 
 

--- a/app/views/projects/edit.html.erb
+++ b/app/views/projects/edit.html.erb
@@ -1,5 +1,6 @@
 <h3>edit a project</h3>
 
+<!-- Find the endpoint task, this will have it's due date changed when project end date is changed-->
 <% @project.tasks.each do | task | %>
 	<% if is_endpoint(task) %>
 		<% @project_end_date = task.due_date %>

--- a/db/migrate/20190127185825_change_owner_to_be_integer_in_orgs.rb
+++ b/db/migrate/20190127185825_change_owner_to_be_integer_in_orgs.rb
@@ -1,0 +1,5 @@
+class ChangeOwnerToBeIntegerInOrgs < ActiveRecord::Migration[5.0]
+  def change
+  	change_column :orgs, :owner, 'integer USING CAST(owner AS integer)'
+  end
+end

--- a/db/migrate/20190128174519_add_manager_column_to_projects.rb
+++ b/db/migrate/20190128174519_add_manager_column_to_projects.rb
@@ -1,0 +1,5 @@
+class AddManagerColumnToProjects < ActiveRecord::Migration[5.0]
+  def change
+  	add_column :projects, :manager, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190122100846) do
+ActiveRecord::Schema.define(version: 20190128174519) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -29,7 +29,7 @@ ActiveRecord::Schema.define(version: 20190122100846) do
   create_table "orgs", force: :cascade do |t|
     t.string   "name"
     t.string   "description"
-    t.string   "owner"
+    t.integer  "owner"
     t.string   "email"
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false
@@ -49,6 +49,7 @@ ActiveRecord::Schema.define(version: 20190122100846) do
     t.integer  "org_id"
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false
+    t.integer  "manager"
     t.index ["org_id"], name: "index_projects_on_org_id", using: :btree
   end
 


### PR DESCRIPTION
for create/accept task and change to start/end for task - notifications go to users/managers as below:-
new endpoint - tp gets notification
accepted endpoint - mngr gets notification on accept
new dependency task created - tp gets notification
dependency task accepted - creating tp gets notification on accept
mngr changes end date of project (i.e. endpoint task) all TPs for all tasks get notification
tp changes duration of a task (due date not changed but changes start date), all tps with task in dep chain for altered task get notification (start date shifts left/right).
NB: if notification goes to mngr send the link to project view, else link to task view and task view only allows edit type access IF TP of task is current user.

Owner of org now coded into owner field on org - not really needed though
Project has a manager field that is a user id > enables notifications to manager of a project.